### PR TITLE
ERC777: Change terminology of the repo, small fix

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -13,7 +13,7 @@
 
 This EIP defines a standard interface for token contracts.
 
-*The official repository for this standard – with a reference implementation – can be found at [jacquesd/ERC777](https://github.com/jacquesd/ERC777) and installed via npm with: `npm install erc777`.*
+*The repository for this standard containing the reference implementation can be found at [jacquesd/ERC777](https://github.com/jacquesd/ERC777) and installed via npm with: `npm install erc777`.*
 
 ## Abstract
 
@@ -326,7 +326,7 @@ The `to` parameter of `tokensToSend` MUST be `0x0`. The operator MUST be `msg.se
 
 <br/>
 
-##### AuthorizeOperator
+##### AuthorizedOperator
 
 ``` ts
 event AuthorizedOperator(address indexed operator, address indexed tokenHolder)
@@ -538,11 +538,11 @@ There is no particular action to take if `tokensToSend` is not implemented. The 
 
 ## Test Cases
 
-The [official repository](https://github.com/jacquesd/ERC777) contains all the [tests](https://github.com/jacquesd/ERC777/blob/master/test/ReferenceToken-test.js).
+The [repository with the reference implementation](https://github.com/jacquesd/ERC777) contains all the [tests](https://github.com/jacquesd/ERC777/blob/master/test/ReferenceToken-test.js).
 
 ## Implementation
 
-The [official repository](https://github.com/jacquesd/ERC777) contains the [reference implementation](https://github.com/jacquesd/ERC777/blob/master/contracts/ReferenceToken.sol).
+The repository at [/jacquesd/ERC777](https://github.com/jacquesd/ERC777) contains the [reference implementation](https://github.com/jacquesd/ERC777/blob/master/contracts/ReferenceToken.sol).
 
 ## Copyright
 


### PR DESCRIPTION
- Don't refer to the repo as the official repo but the repo of the
  reference implementation
- Fix a small typo in the AuthorizedOperator event