### PR TITLE
Use markdown instead of html and relative links & adapt EIP template

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1,13 +1,14 @@
-## Preamble
-
-    EIP: 777
-    Title: A New Advanced Token Standard
-    Author: Jordi Baylina @jbaylina, Jacques Dafflon @jacquesd, Thomas Shababi @tshabs
-    Type: Standard Track
-    Category: ERC
-    Status: Draft
-    Created: 2017-11-19
-    Requires: 820
+---
+eip: 777
+title: A New Advanced Token Standard
+author: Jordi Baylina @jbaylina, Jacques Dafflon @jacquesd, Thomas Shababi @tshabs
+status: Draft
+type: ERC
+category: ERC
+created: 2017-11-20
+requires: 820
+replaces: 20
+---
 
 ## Simple Summary
 

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -450,36 +450,14 @@ When tokens are received as a result of sending (`send` or `operatorSend`):
 If it is a direct `send` (i.e. not an `operatorSend`) the `operator` MUST be the address from which the tokens originate. That is the `from` and `operator` addresses MUST be equals.
 
 ### Logo
-<table>
-  <tr>
-    <th>Image</th>
-    <th><img src="https://github.com/ethereum/EIPs/blob/master/EIPs/eip-777/logo/png/ERC-777-logo-beige-192px.png?raw=true" height="46px" align="top"></img></th>
-    <th><img src="https://github.com/ethereum/EIPs/blob/master/EIPs/eip-777/logo/png/ERC-777-logo-white-192px.png?raw=true" height="46px" align="top"></img></th>
-    <th><img src="https://github.com/ethereum/EIPs/blob/master/EIPs/eip-777/logo/png/ERC-777-logo-light_grey-192px.png?raw=true" height="46px" align="top"></img></th>
-    <th><img src="https://github.com/ethereum/EIPs/blob/master/EIPs/eip-777/logo/png/ERC-777-logo-dark_grey-192px.png?raw=true" height="46px" align="top"></img></th>
-    <th><img src="https://github.com/ethereum/EIPs/blob/master/EIPs/eip-777/logo/png/ERC-777-logo-black-192px.png?raw=true" height="46px" align="top"></img></th>
-  </tr>
-  <tr>
-    <th>Color</th>
-    <td>beige</td>
-    <td>white</td>
-    <td>light grey<br></td>
-    <td>dark grey<br></td>
-    <td>black</td>
-  </tr>
-  <tr>
-    <th>Hex</th>
-    <td><code>#C99D66</code></td>
-    <td><code>#FFFFFF</code></td>
-    <td><code>#EBEFF0</code></td>
-    <td><code>#3C3C3D</code></td>
-    <td><code>#000000</code></td>
-  </tr>
-</table>
+| **Image** | &nbsp;![beige logo](/EIPS/eip-777/logo/png/ERC-777-logo-beige-48px.png) | &nbsp;![white logo](/EIPS/eip-777/logo/png/ERC-777-logo-white-48px.png) | &nbsp;![light grey logo](/EIPS/eip-777/logo/png/ERC-777-logo-light_grey-48px.png) | &nbsp;![dark grey logo](/EIPS/eip-777/logo/png/ERC-777-logo-dark_grey-48px.png) | &nbsp;![black logo](/EIPS/eip-777/logo/png/ERC-777-logo-black-48px.png?raw=true)
+|----------:|:---------:|:---------:|:------------:|:-----------:|:---------:|
+| **Color** | beige     | white     | light grey   | dark grey   | black     |
+| **Hex**   | `#C99D66` | `#FFFFFF` | `#EBEFF0`    | `#3C3C3D`   | `#000000` |
 
 The logo MUST NOT be used to advertise, promote or associate in any way technology – such as tokens – which is not ERC777 compliant.
 
-The logo for the standard can be found in the [eip-777/logo](https://github.com/ethereum/EIPs/tree/master/EIPS/eip-777/logo) folder in [svg](https://github.com/ethereum/EIPs/tree/master/EIPS/eip-777/logo/svg) and [png](https://github.com/ethereum/EIPs/tree/master/EIPS/eip-777/logo/png) formats. The `png` version of the logo offers a dew sizes in pixel. If needed, other sizes CAN be created by converting from `svg` into `png`.
+The logo for the standard can be found in the [eip-777/logo](/EIPS/eip-777/logo) folder in [svg](/EIPS/eip-777/logo/svg) and [png](/EIPS/eip-777/logo/png) formats. The `png` version of the logo offers a few sizes in pixel. If needed, other sizes CAN be created by converting from `svg` into `png`.
 
 ERC777 token contract authors CAN create a specific logo for their token based on this logo.
 
@@ -512,27 +490,33 @@ The table below summarize the different actions the token contract must take whe
 <table>
   <tr>
     <th>ERC820</th>
-    <th><code>to</code> address<br></th>
-    <th>ERC777 <code>send</code>/<code>operatorSend</code> and Minting<br></th>
-    <th>ERC20 <code>transfer</code><br></th>
+    <th><code>to</code> address</th>
+    <th>ERC777 <code>send</code>/<code>operatorSend</code> and Minting</th>
+    <th>ERC20 <code>transfer</code></th>
   </tr>
   <tr>
-    <td rowspan="2"><code>ERC777TokensRecipient</code> registered<br></td>
+    <td rowspan="2" align="right">
+      <code>ERC777TokensRecipient</code><br/>registered
+    </td>
     <td>regular address</td>
-    <td colspan="2" rowspan="2">Call <code>tokensReceived</code><br></td>
+    <td colspan="2" rowspan="2" align="center">
+      MUST call <code>tokensReceived</code>
+    </td>
   </tr>
   <tr>
     <td>contract</td>
   </tr>
   <tr>
-    <td rowspan="2"><code>ERC777TokensRecipient</code> not registered</td>
+    <td rowspan="2" align="right">
+      <code>ERC777TokensRecipient</code><br/>not registered
+    </td>
     <td>regular address</td>
-    <td>SHOULD accept<br></td>
-    <td rowspan="2">SHOULD accept<br></td>
+    <td align="center">SHOULD accept</td>
+    <td rowspan="2" align="center">SHOULD accept</td>
   </tr>
   <tr>
     <td>contract</td>
-    <td>MUST throw<br></td>
+    <td align="center">MUST throw</td>
   </tr>
 </table>
 


### PR DESCRIPTION
- Use markdown instead of html and relative links
- Adapt to new EIP template